### PR TITLE
specify vte-2.91 in configure.ac and replace inner_border with gtk_widget_get_margin

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -48,7 +48,7 @@ AS_IF([test "x$enable_gtk3" = "xyes"], [
 
 	AC_SUBST(HAVE_GLADE_LIB, 0)
 
-	vte_lib="vte >= 0.29.0"
+	vte_lib="vte-2.91 >= 0.29.0"
 	PKG_CHECK_MODULES([VTE], \
 		[$vte_lib], \
 		AC_SUBST(HAVE_VTE, 1),\

--- a/src/automaton.c
+++ b/src/automaton.c
@@ -778,14 +778,16 @@ static GtkWidget *put_in_the_scrolled_window(GtkWidget *widget,
 			 * named 'inner-border' so I have to go with the deprecated
 			 * vte_terminal_get_padding() */
 #if VTE_CHECK_VERSION(0,26,0)
-			g_object_get(G_OBJECT(widget), "inner-border", &inner_border, NULL);
+//			g_object_get(G_OBJECT(widget), "inner-border", &inner_border, NULL);
 #ifdef DEBUG_CONTENT
-			fprintf(stderr, "%s(): inner_border.left=%i inner_border.right=%i \
-inner_border.top=%i inner_border.bottom=%i\n", __func__, inner_border.left,
-				inner_border.right, inner_border.top, inner_border.bottom);
+//			fprintf(stderr, "%s(): inner_border.left=%i inner_border.right=%i \
+//inner_border.top=%i inner_border.bottom=%i\n", __func__, inner_border.left,
+//				inner_border.right, inner_border.top, inner_border.bottom);
 #endif
-			xpad = inner_border.left + inner_border.right;
-			ypad = inner_border.top + inner_border.bottom;
+//			xpad = inner_border.left + inner_border.right;
+//			ypad = inner_border.top + inner_border.bottom;
+			ypad = gtk_widget_get_margin_bottom(G_OBJECT(widget));
+			xpad = gtk_widget_get_margin_right(G_OBJECT(widget));
 #else
 			vte_terminal_get_padding(VTE_TERMINAL(widget), &xpad, &ypad);
 #endif


### PR DESCRIPTION
don't know if these will work for you with debian/puppy, but they seem to be effective with slackware-current based porteus ..
specifying vte-2.91 removes the need to export VTE_CFLAGS and VTE_LIBS  ...here at least
and replace inner_border with gtk_widget_get_margin removes an error message about inner_border.
it could be that this is dependent on gtk+3 version..